### PR TITLE
Add the integers package.

### DIFF
--- a/packages/integers-android.0.2.2/descr
+++ b/packages/integers-android.0.2.2/descr
@@ -1,0 +1,1 @@
+Various signed and unsigned integer types for OCaml

--- a/packages/integers-android.0.2.2/opam
+++ b/packages/integers-android.0.2.2/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer: "yallop@gmail.com"
+authors: ["Jeremy Yallop"
+          "Demi Obenour"
+          "Stephane Glondu"
+          "Andreas Hauptmann"]
+homepage: "https://github.com/ocamllabs/ocaml-integers"
+bug-reports: "https://github.com/ocamllabs/ocaml-integers/issues"
+dev-repo: "https://github.com/ocamllabs/ocaml-integers.git"
+license: "MIT"
+build:
+[[ "ocaml" "pkg/pkg.ml" "build"
+           "--pinned" "%{pinned}%"
+           "--toolchain" "android"]]
+install: [["opam-installer" "--prefix=%{prefix}%/android-sysroot" "integers.install"]]
+remove: [["ocamlfind" "-toolchain" "android" "remove" "integers"]]
+depends: [
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+  "topkg" {build}
+]
+
+doc: "http://ocamllabs.github.io/ocaml-integers/api.docdir/"

--- a/packages/integers-android.0.2.2/url
+++ b/packages/integers-android.0.2.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocamllabs/ocaml-integers/releases/download/v0.2.2/integers-0.2.2.tbz"
+checksum: "ae226532930965fe0b43c02f2469cadc"


### PR DESCRIPTION
I haven't tested this extensively, but it appears to correctly pass the `-toolchain android` flags through to `ocamlfind` and install the package files in the correct location.

This also seems to fix the ctypes Travis build for Android for this PR https://github.com/ocamllabs/ocaml-ctypes/pull/515 (see [Travis build logs](https://travis-ci.org/yallop/ocaml-ctypes/builds/231530276)).